### PR TITLE
chore(release): publish 1.0.0-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,185 +1,166 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-# [0.9.0](https://github.com/hidoo/unit-sass/compare/v0.8.0...v0.9.0) (2023-04-17)
+# [1.0.0-alpha.0](https://github.com/hidoo/stylelint-config/compare/v0.9.0...v1.0.0-alpha.0) (2024-03-01)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency postcss to v8.4.22 ([a92d5f2](https://github.com/hidoo/unit-sass/commit/a92d5f200373eb822d6a10ab85fd42cc44538aff))
-* **stylelint-config:** update target browsers ([a7548cc](https://github.com/hidoo/unit-sass/commit/a7548cc2ec7343e88a22c87f8ab1242210931d90))
+* apply feed backs from active projects ([e8d0ebc](https://github.com/hidoo/stylelint-config/commit/e8d0ebcb30d565992615aaefa2184ffd27025a38))
+* **deps:** update dependency postcss to v8.4.23 ([859b377](https://github.com/hidoo/stylelint-config/commit/859b37765c2df41e3897ac1c290986d0659d129b))
+* **deps:** update dependency postcss to v8.4.29 ([3257625](https://github.com/hidoo/stylelint-config/commit/3257625f156992e2f158b59de03db0320e7b79d6))
+* **deps:** update dependency postcss to v8.4.31 ([5ea43cd](https://github.com/hidoo/stylelint-config/commit/5ea43cd678f18a680f81e8b12ed6f54d5386a3da))
+* **deps:** update dependency postcss to v8.4.33 ([78badcb](https://github.com/hidoo/stylelint-config/commit/78badcbbd6f48e9c2ca1f08c7d2bab20684e4e46))
+* **deps:** update dependency postcss-scss to v4.0.6 ([e70f6a6](https://github.com/hidoo/stylelint-config/commit/e70f6a6cc2238e0e0ead2c80b55d1faf6330155b))
+* **deps:** update dependency postcss-scss to v4.0.8 ([cab6a3a](https://github.com/hidoo/stylelint-config/commit/cab6a3a71bc32f52d00a09c6112aa5374de21df7))
+* **deps:** update dependency postcss-scss to v4.0.9 ([d461ba5](https://github.com/hidoo/stylelint-config/commit/d461ba5634392f0fe3e8a764edd7e6c5f5784beb))
+* disable stylistic rules in scss syntax to avoid conflict with prettier ([2c31636](https://github.com/hidoo/stylelint-config/commit/2c3163601d662f228829d584e0c6d9c165020415))
 
 
 
-
-
-# [0.8.0](https://github.com/hidoo/unit-sass/compare/v0.7.0...v0.8.0) (2022-07-13)
+# [0.9.0](https://github.com/hidoo/stylelint-config/compare/v0.8.0...v0.9.0) (2023-04-17)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency postcss to v8.4.14 ([1d66b47](https://github.com/hidoo/unit-sass/commit/1d66b473507f681bc60aa132e2bfa415c76d774c))
-* **deps:** update dependency postcss-scss to v4.0.4 ([def578e](https://github.com/hidoo/unit-sass/commit/def578eb5030e7bf18420d09aff35d2b91772235))
+* **deps:** update dependency postcss to v8.4.22 ([c610fc6](https://github.com/hidoo/stylelint-config/commit/c610fc6a559bb2a93534135629c867a8bca9081b))
+* **stylelint-config:** update target browsers ([02df49c](https://github.com/hidoo/stylelint-config/commit/02df49c7520fb45abd86c8fdfa808abdc200e588))
+
+
+
+# [0.8.0](https://github.com/hidoo/stylelint-config/compare/v0.7.0...v0.8.0) (2022-07-13)
+
+
+### Bug Fixes
+
+* **deps:** update dependency postcss to v8.4.14 ([f173aa1](https://github.com/hidoo/stylelint-config/commit/f173aa1b5d2639ce04838e17eae616e8444d4c7d))
+* **deps:** update dependency postcss-scss to v4.0.4 ([5b3bfea](https://github.com/hidoo/stylelint-config/commit/5b3bfeaeca15e753578c58cd5e07082bda0e9916))
 
 
 ### Features
 
-* **stylelint-config:** enable keyframe-block-no-duplicate-selectors rules ([dbcf7c4](https://github.com/hidoo/unit-sass/commit/dbcf7c41ec4057308b7b3570d2f1a9e3dc3a9dcc))
+* **stylelint-config:** enable keyframe-block-no-duplicate-selectors rules ([ad70a96](https://github.com/hidoo/stylelint-config/commit/ad70a9669272515e7e4ad99840c64057372f7c76))
 
 
 
-
-
-# [0.7.0](https://github.com/hidoo/unit-sass/compare/v0.6.0...v0.7.0) (2022-01-20)
+# [0.7.0](https://github.com/hidoo/stylelint-config/compare/v0.6.0...v0.7.0) (2022-01-20)
 
 
 ### Bug Fixes
 
-* **deps:** update stylelint packages ([63e9911](https://github.com/hidoo/unit-sass/commit/63e991177c46ee9e26f1cfe344eb3a920ff04c58))
-* **deps:** update stylelint packages ([4812d22](https://github.com/hidoo/unit-sass/commit/4812d22700ef812dad07418cb20b39d1957ba024))
-* **deps:** update stylelint packages and update rules ([0331e7e](https://github.com/hidoo/unit-sass/commit/0331e7e860bb7ab2980602c8f23f355f371d0d22))
+* **deps:** update stylelint packages ([c1299c0](https://github.com/hidoo/stylelint-config/commit/c1299c0c04460b6a4159370c41f943842b2186fa))
+* **deps:** update stylelint packages ([d6f0a03](https://github.com/hidoo/stylelint-config/commit/d6f0a03fcb67461f1dcddcb27290e16020c47b9a))
+* **deps:** update stylelint packages and update rules ([02d26ed](https://github.com/hidoo/stylelint-config/commit/02d26ede526e5f531a2192509c07ca0d761fff57))
 
 
 ### Features
 
-* **stylelint-config:** update options of scss/at-function-named-arguments ([35cee26](https://github.com/hidoo/unit-sass/commit/35cee26a3a1727ca2359b3e7b6a14f45dfaf21fe))
+* **stylelint-config:** update options of scss/at-function-named-arguments ([cf4c795](https://github.com/hidoo/stylelint-config/commit/cf4c795c43bd7fad337d2411636ca80b113eb3e3))
 
 
 
-
-
-# [0.6.0](https://github.com/hidoo/unit-sass/compare/v0.5.0...v0.6.0) (2021-06-09)
-
-
-### Features
-
-* **stylelint-config:** enable scss/no-global-function-names rule ([d8dbc4e](https://github.com/hidoo/unit-sass/commit/d8dbc4e763189828e6db1c4a69848d9c5897adef))
-
-
-
-
-
-# [0.5.0](https://github.com/hidoo/unit-sass/compare/v0.4.4...v0.5.0) (2021-06-08)
-
-
-### Bug Fixes
-
-* **deps:** update stylelint packages ([cfadd5a](https://github.com/hidoo/unit-sass/commit/cfadd5a940453c9ce4fc69156056ed6e4b798881))
-* **stylelint-config:** disable no-invalid-position-at-import-rule in sass config ([44b809e](https://github.com/hidoo/unit-sass/commit/44b809edaced4455ccaadb208b7c78cdab263ea6))
-
-
-
-
-
-## [0.4.4](https://github.com/hidoo/unit-sass/compare/v0.4.2...v0.4.4) (2021-03-31)
-
-
-### Bug Fixes
-
-* **deps:** update dependency stylelint-config-standard to v21 ([0a4f9e7](https://github.com/hidoo/unit-sass/commit/0a4f9e749593c64f45b862181046d7897e9a7ad8))
-* **deps:** update dependency stylelint-group-selectors to v1.0.8 ([6b0a8cb](https://github.com/hidoo/unit-sass/commit/6b0a8cb3b0f994296b0333805e2c0334e27da157))
-* **deps:** update dependency stylelint-high-performance-animation to v1.5.2 ([81348c9](https://github.com/hidoo/unit-sass/commit/81348c9ba984f622653e32aa6575615e3227a71e))
-* **deps:** update dependency stylelint-scss to v3.17.2 ([353a0e1](https://github.com/hidoo/unit-sass/commit/353a0e19c44012ac79d8cf2bdf3ed4df6886d43b))
-
-
-
-
-
-## [0.4.3](https://github.com/hidoo/unit-sass/compare/v0.4.2...v0.4.3) (2021-03-31)
-
-
-### Bug Fixes
-
-* **deps:** update dependency stylelint-config-standard to v21 ([0a4f9e7](https://github.com/hidoo/unit-sass/commit/0a4f9e749593c64f45b862181046d7897e9a7ad8))
-* **deps:** update dependency stylelint-group-selectors to v1.0.8 ([6b0a8cb](https://github.com/hidoo/unit-sass/commit/6b0a8cb3b0f994296b0333805e2c0334e27da157))
-* **deps:** update dependency stylelint-high-performance-animation to v1.5.2 ([81348c9](https://github.com/hidoo/unit-sass/commit/81348c9ba984f622653e32aa6575615e3227a71e))
-* **deps:** update dependency stylelint-scss to v3.17.2 ([353a0e1](https://github.com/hidoo/unit-sass/commit/353a0e19c44012ac79d8cf2bdf3ed4df6886d43b))
-
-
-
-
-
-## [0.4.2](https://github.com/hidoo/unit-sass/compare/v0.4.1...v0.4.2) (2020-05-08)
-
-
-### Bug Fixes
-
-* **deps:** update dependency stylelint-a11y to v1.2.3 ([b0be228](https://github.com/hidoo/unit-sass/commit/b0be228a976e1352d8529b9a8c207cda52a44bc1))
-* **deps:** update dependency stylelint-config-standard to v20 ([7a03ede](https://github.com/hidoo/unit-sass/commit/7a03edefd2d2368765a7d361b00b849e2aae2819))
-* **deps:** update dependency stylelint-high-performance-animation to v1.4.0 ([a4eea33](https://github.com/hidoo/unit-sass/commit/a4eea3385af666b3194371da60f3e258aed3aa2f))
-* **deps:** update dependency stylelint-scss to v3.14.2 ([fec61bf](https://github.com/hidoo/unit-sass/commit/fec61bfecd9b7ac4664ff4f43dc52d4fab1a78b5))
-* **deps:** update dependency stylelint-scss to v3.15.0 ([8164bc0](https://github.com/hidoo/unit-sass/commit/8164bc0987ee18961526ee69b4e8ea55bca03538))
-* **deps:** update dependency stylelint-scss to v3.16.0 ([fe27868](https://github.com/hidoo/unit-sass/commit/fe27868f2109f078462138e33ba12b642b7941a5))
-* **deps:** update dependency stylelint-scss to v3.17.1 ([754b3ae](https://github.com/hidoo/unit-sass/commit/754b3aef0bcc6bad3a3d4071d53d0f6bee1e77b1))
-* **deps:** update dependency stylelint-selector-tag-no-without-class to v2.0.3 ([812a19d](https://github.com/hidoo/unit-sass/commit/812a19de01ca593b8b51934a5a85991f721a1136))
-* **deps:** update stylelint packages ([f670b56](https://github.com/hidoo/unit-sass/commit/f670b56ff3ed6f438c41110d7dbb861b4394e203))
-* **deps:** update stylelint packages ([425b087](https://github.com/hidoo/unit-sass/commit/425b087516e6668d7ba32e91943a72bd2189f4c1))
-* **stylelint-config:** ignore sass variables in value-keyword-case rule ([bd270f1](https://github.com/hidoo/unit-sass/commit/bd270f15be8b41369fd24db0c763d59a3567d663))
-
-
-
-
-
-## [0.4.1](https://github.com/hidoo/unit-sass/compare/v0.4.0...v0.4.1) (2019-11-11)
-
-
-### Bug Fixes
-
-* **deps:** update dependency stylelint-a11y to v1.2.2 ([7759fa4](https://github.com/hidoo/unit-sass/commit/7759fa4))
-* **deps:** update dependency stylelint-high-performance-animation to v1.3.0 ([d6d23ea](https://github.com/hidoo/unit-sass/commit/d6d23ea))
-* **deps:** update dependency stylelint-no-unsupported-browser-features to v4 ([c0f5f8f](https://github.com/hidoo/unit-sass/commit/c0f5f8f))
-* **deps:** update dependency stylelint-order to v3.1.1 ([cd15f08](https://github.com/hidoo/unit-sass/commit/cd15f08))
-* **deps:** update dependency stylelint-scss to v3.11.1 ([5f5ff2e](https://github.com/hidoo/unit-sass/commit/5f5ff2e))
-* **deps:** update dependency stylelint-scss to v3.12.1 ([1271d3b](https://github.com/hidoo/unit-sass/commit/1271d3b))
-* **deps:** update dependency stylelint-selector-tag-no-without-class to v2.0.2 ([363938e](https://github.com/hidoo/unit-sass/commit/363938e))
-
-
-
-
-
-# [0.4.0](https://github.com/hidoo/unit-sass/compare/v0.3.1...v0.4.0) (2019-09-17)
-
-
-### Bug Fixes
-
-* **stylelint-config:** change required stylelint version to 10.1.0+ ([7938d9e](https://github.com/hidoo/unit-sass/commit/7938d9e))
-* **stylelint-config:** disabled unicode-bom ([6903eb0](https://github.com/hidoo/unit-sass/commit/6903eb0))
+# [0.6.0](https://github.com/hidoo/stylelint-config/compare/v0.5.0...v0.6.0) (2021-06-09)
 
 
 ### Features
 
-* **stylelint-config:** add rules that added in stylelint-scss ([94fbc0a](https://github.com/hidoo/unit-sass/commit/94fbc0a))
-* **stylelint-config:** add unicode-bom rule ([502b29b](https://github.com/hidoo/unit-sass/commit/502b29b))
+* **stylelint-config:** enable scss/no-global-function-names rule ([5326196](https://github.com/hidoo/stylelint-config/commit/532619618de5de529e3de064f6b48023cac66f38))
 
 
 
+# [0.5.0](https://github.com/hidoo/stylelint-config/compare/v0.4.4...v0.5.0) (2021-06-08)
 
 
-# [0.3.0](https://github.com/hidoo/unit-sass/compare/v0.2.0...v0.3.0) (2019-08-21)
+### Bug Fixes
 
-**Note:** Version bump only for package @hidoo/stylelint-config
-
-
-
+* **deps:** update stylelint packages ([f98b161](https://github.com/hidoo/stylelint-config/commit/f98b161a50aa4b395c37cafc1f6c101b707af216))
+* **stylelint-config:** disable no-invalid-position-at-import-rule in sass config ([3cab5ea](https://github.com/hidoo/stylelint-config/commit/3cab5eab88727fc6206e56ea9cf8f20a3bc061fe))
 
 
-# [0.2.0](https://github.com/hidoo/unit-sass/compare/v0.1.0...v0.2.0) (2019-08-14)
+
+## [0.4.4](https://github.com/hidoo/stylelint-config/compare/v0.4.3...v0.4.4) (2021-03-31)
+
+
+
+## [0.4.3](https://github.com/hidoo/stylelint-config/compare/v0.4.2...v0.4.3) (2021-03-31)
+
+
+### Bug Fixes
+
+* **deps:** update dependency stylelint-config-standard to v21 ([977bfe8](https://github.com/hidoo/stylelint-config/commit/977bfe84410d14709fd958ad05a71e115bf19b3c))
+* **deps:** update dependency stylelint-group-selectors to v1.0.8 ([c8adb9b](https://github.com/hidoo/stylelint-config/commit/c8adb9b00f845f06d95a8d2825f7782361609602))
+* **deps:** update dependency stylelint-high-performance-animation to v1.5.2 ([17e4971](https://github.com/hidoo/stylelint-config/commit/17e4971415a683657e0518816d26c5b2005a5455))
+* **deps:** update dependency stylelint-scss to v3.17.2 ([d53d590](https://github.com/hidoo/stylelint-config/commit/d53d5906ad3ee076ad2feb7fe8786e4265c69112))
+
+
+
+## [0.4.2](https://github.com/hidoo/stylelint-config/compare/v0.4.1...v0.4.2) (2020-05-08)
+
+
+### Bug Fixes
+
+* **deps:** update dependency stylelint-a11y to v1.2.3 ([6bd3ed1](https://github.com/hidoo/stylelint-config/commit/6bd3ed10b8886a709b65920c4af95a6ea6c99d1c))
+* **deps:** update dependency stylelint-config-standard to v20 ([3ffa9fb](https://github.com/hidoo/stylelint-config/commit/3ffa9fb5faf232c2b03b682a41ada0158950685b))
+* **deps:** update dependency stylelint-high-performance-animation to v1.4.0 ([3257948](https://github.com/hidoo/stylelint-config/commit/3257948c5083a9316bae8b9c62cd4d31fa35f684))
+* **deps:** update dependency stylelint-scss to v3.14.2 ([7f158d3](https://github.com/hidoo/stylelint-config/commit/7f158d377ee45b9be9abfa58950a19e6443870e6))
+* **deps:** update dependency stylelint-scss to v3.15.0 ([3521b01](https://github.com/hidoo/stylelint-config/commit/3521b01c83e0f44422334ede4cf7e10bd1c59d65))
+* **deps:** update dependency stylelint-scss to v3.16.0 ([f4aef68](https://github.com/hidoo/stylelint-config/commit/f4aef682c53ee7df5c0fe9e2385c0d5f320f654f))
+* **deps:** update dependency stylelint-scss to v3.17.1 ([0643ad5](https://github.com/hidoo/stylelint-config/commit/0643ad58229f3f9bb94c4eca10dc224264881ab1))
+* **deps:** update dependency stylelint-selector-tag-no-without-class to v2.0.3 ([6f78913](https://github.com/hidoo/stylelint-config/commit/6f78913a2c908080315a086f667e338a8561ee8c))
+* **deps:** update stylelint packages ([4d95c68](https://github.com/hidoo/stylelint-config/commit/4d95c686b38627f355cedc31d1d074a946075fc1))
+* **deps:** update stylelint packages ([7911107](https://github.com/hidoo/stylelint-config/commit/791110711618290460d6df0ad57088b98c2dcc13))
+* **stylelint-config:** ignore sass variables in value-keyword-case rule ([0c1f43d](https://github.com/hidoo/stylelint-config/commit/0c1f43d3267b9d3a77d1c3f2ecc38c57625f66d9))
+
+
+
+## [0.4.1](https://github.com/hidoo/stylelint-config/compare/v0.4.0...v0.4.1) (2019-11-11)
+
+
+### Bug Fixes
+
+* **deps:** update dependency stylelint-a11y to v1.2.2 ([19d8018](https://github.com/hidoo/stylelint-config/commit/19d8018a8645ef42f3adb5adf2eb4facfcacd9ba))
+* **deps:** update dependency stylelint-high-performance-animation to v1.3.0 ([1514dd3](https://github.com/hidoo/stylelint-config/commit/1514dd37082da74c9c9ef582c403888a0a2ee569))
+* **deps:** update dependency stylelint-no-unsupported-browser-features to v4 ([3900744](https://github.com/hidoo/stylelint-config/commit/3900744382ddabb2203908e7f909e4d951b89260))
+* **deps:** update dependency stylelint-order to v3.1.1 ([8c2dd1b](https://github.com/hidoo/stylelint-config/commit/8c2dd1b1a2e4177f9826b039ecb0c0d510aaf50a))
+* **deps:** update dependency stylelint-scss to v3.11.1 ([f26f300](https://github.com/hidoo/stylelint-config/commit/f26f300dd8b8d6e48a619619fd2fcd5a4dfc1965))
+* **deps:** update dependency stylelint-scss to v3.12.1 ([5fc7177](https://github.com/hidoo/stylelint-config/commit/5fc7177481082735c08abb13b76b23c78c166208))
+* **deps:** update dependency stylelint-selector-tag-no-without-class to v2.0.2 ([e3ba22e](https://github.com/hidoo/stylelint-config/commit/e3ba22e74526816d68f6331f649c817cbe05fdd5))
+
+
+
+# [0.4.0](https://github.com/hidoo/stylelint-config/compare/v0.3.0...v0.4.0) (2019-09-17)
+
+
+### Bug Fixes
+
+* **stylelint-config:** change required stylelint version to 10.1.0+ ([ee5114b](https://github.com/hidoo/stylelint-config/commit/ee5114bdd3ce4053318060c5635423af980fe2d1))
+* **stylelint-config:** disabled unicode-bom ([35490ac](https://github.com/hidoo/stylelint-config/commit/35490ac5cfee124f23abc7788f06ad15328c65aa))
 
 
 ### Features
 
-* **stylelint-config:** add word-break to properties-order settings ([85b825a](https://github.com/hidoo/unit-sass/commit/85b825a))
+* **stylelint-config:** add rules that added in stylelint-scss ([acee519](https://github.com/hidoo/stylelint-config/commit/acee5190a0cbd11eb6b5cba370ee7adec4a2b0ff))
+* **stylelint-config:** add unicode-bom rule ([25c6c8a](https://github.com/hidoo/stylelint-config/commit/25c6c8a3c02b2693dd69acca143a28323a67cce7))
 
 
 
+# [0.3.0](https://github.com/hidoo/stylelint-config/compare/v0.2.0...v0.3.0) (2019-08-21)
 
 
-# 0.1.0 (2019-08-02)
+
+# [0.2.0](https://github.com/hidoo/stylelint-config/compare/v0.1.0...v0.2.0) (2019-08-14)
 
 
 ### Features
 
-* **stylelint-config:** add package that sharable stylelint config ([a8c174c](https://github.com/hidoo/unit-sass/commit/a8c174c))
-* **stylelint-config:** add sharable stylelint config ([d0dbe89](https://github.com/hidoo/unit-sass/commit/d0dbe89))
+* **stylelint-config:** add word-break to properties-order settings ([368e5d1](https://github.com/hidoo/stylelint-config/commit/368e5d187d04c898b0398f32830d6e624c701768))
+
+
+
+# [0.1.0](https://github.com/hidoo/stylelint-config/compare/3ede02ec2fa302a1092d7c4fd325fa01fa56d5e0...v0.1.0) (2019-08-02)
+
+
+### Features
+
+* **stylelint-config:** add package that sharable stylelint config ([699bdde](https://github.com/hidoo/stylelint-config/commit/699bddee608f2e7be24d63c31809e42dac4b6482))
+* **stylelint-config:** add sharable stylelint config ([3ede02e](https://github.com/hidoo/stylelint-config/commit/3ede02ec2fa302a1092d7c4fd325fa01fa56d5e0))
+
+
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hidoo/stylelint-config",
-  "version": "0.9.0",
+  "version": "1.0.0-alpha.0",
   "description": "Sharable stylelint config for my projects.",
   "packageManager": "pnpm@8.15.3",
   "engines": {


### PR DESCRIPTION
### BREAKING CHANGES

+ Migrate to stylelint v16
+ Drop Node.js v14 and v16
+ Require ES Modules
+ Disable stylelint-a11y rules (Because it does not work with stylelint v16)
