### PR TITLE
chore(release): publish 1.0.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [1.0.0-alpha.1](https://github.com/hidoo/stylelint-config/compare/v1.0.0-alpha.0...v1.0.0-alpha.1) (2024-03-04)
+
+
+### Bug Fixes
+
+* **order:** change to use stylelint-config-clean-order based order ([7732847](https://github.com/hidoo/stylelint-config/commit/773284729622ec3c02a2259336ee8196896521ed))
+
+
+
 # [1.0.0-alpha.0](https://github.com/hidoo/stylelint-config/compare/v0.9.0...v1.0.0-alpha.0) (2024-03-01)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hidoo/stylelint-config",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "description": "Sharable stylelint config for my projects.",
   "packageManager": "pnpm@8.15.4",
   "engines": {


### PR DESCRIPTION
### BREAKING CHANGES

+ change to use new order rules based on [stylelint-config-clean-order](https://github.com/kutsan/stylelint-config-clean-order/)