### PR TITLE
fix: severity tweaks

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -111,7 +111,12 @@ export default {
 
     // csstools/value-no-unknown-custom-properties
     // use instead of no-unknown-custom-properties rule
-    'csstools/value-no-unknown-custom-properties': true,
+    'csstools/value-no-unknown-custom-properties': [
+      true,
+      {
+        severity: 'warning'
+      }
+    ],
 
     // plugin/stylelint-declaration-block-no-ignored-properties
     'plugin/declaration-block-no-ignored-properties': true,

--- a/src/performance.js
+++ b/src/performance.js
@@ -4,7 +4,8 @@ export default {
     'plugin/no-low-performance-animation-properties': [
       true,
       {
-        ignore: 'paint-properties'
+        ignore: 'paint-properties',
+        severity: 'warning'
       }
     ]
   }

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -103,7 +103,6 @@ describe('base', () => {
           'selector-class-pattern',
           'selector-id-pattern',
           'value-keyword-case',
-          'csstools/value-no-unknown-custom-properties',
           'plugin/declaration-block-no-ignored-properties',
           'plugin/stylelint-group-selectors',
           'plugin/stylelint-selector-no-empty',
@@ -121,7 +120,8 @@ describe('base', () => {
           'selector-max-pseudo-class',
           'selector-max-specificity',
           'selector-max-type',
-          'selector-max-universal'
+          'selector-max-universal',
+          'csstools/value-no-unknown-custom-properties'
         ].sort(),
         'Some warnings.'
       );

--- a/test/performance.test.js
+++ b/test/performance.test.js
@@ -94,12 +94,12 @@ describe('performance', () => {
         )
       ];
 
+      assert.deepEqual(errors, [], 'No errors.');
       assert.deepEqual(
-        errors,
+        warnings,
         ['plugin/no-low-performance-animation-properties'],
-        'Some errors.'
+        'Some warnings.'
       );
-      assert.deepEqual(warnings, [], 'No warnings.');
     });
   });
 });


### PR DESCRIPTION
### Changes
+ Change severity of following rules  to `warning`.
  + `csstools/value-no-unknown-custom-properties`
  + `plugin/no-low-performance-animation-properties`