### PR TITLE
fix(scss): configure scss/at-mixin-no-risky-nesting-selector rule

### DIFF
--- a/src/scss.js
+++ b/src/scss.js
@@ -64,6 +64,12 @@ export default {
         ignore: ['single-argument']
       }
     ],
+    'scss/at-mixin-no-risky-nesting-selector': [
+      true,
+      {
+        severity: 'warning'
+      }
+    ],
     'scss/at-mixin-pattern': identifierPattern('mixin name'),
     'scss/at-root-no-redundant': true,
     'scss/at-use-no-redundant-alias': true,

--- a/test/fixture/_invalid.scss
+++ b/test/fixture/_invalid.scss
@@ -204,3 +204,14 @@ $dollar-variable-default: true;
 }
 
 // scss/selector-no-union-class-name -> disabled, for support BEM syntax
+
+// scss/at-mixin-no-risky-nesting-selector
+@mixin at-mixin-no-risky-nesting-selector {
+  .bar {
+    color: blue;
+
+    .baz & {
+      color: red;
+    }
+  }
+}

--- a/test/fixture/_valid.scss
+++ b/test/fixture/_valid.scss
@@ -257,3 +257,14 @@ $dollar-variable-default: true !default;
     // no settings
   }
 }
+
+// scss/at-mixin-no-risky-nesting-selector
+@mixin at-mixin-no-risky-nesting-selector {
+  .bar {
+    color: blue;
+
+    .baz {
+      color: red;
+    }
+  }
+}

--- a/test/scss.test.js
+++ b/test/scss.test.js
@@ -128,6 +128,7 @@ describe('scss', () => {
         warnings,
         [
           'at-rule-disallowed-list',
+          'scss/at-mixin-no-risky-nesting-selector',
           'scss/dollar-variable-first-in-block',
           'scss/no-duplicate-dollar-variables'
         ],


### PR DESCRIPTION
### Changes
+ Configure `scss/at-mixin-no-risky-nesting-selector` rule (added in `stylelint-scss` v6.3.0)